### PR TITLE
Change Xvfb path to BUILD_DIR

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -79,7 +79,7 @@ freedom_patch_xvfb() {
 	topic "Configuring Xvfb for apt"
 
 	# patch Xvfb to use /app/.. paths instead of hardcoded wrong values
-	sed -i s:/usr/bin:/app/nib: "/app/.apt/usr/bin/Xvfb"
+	sed -i s:/usr/bin:/app/nib: $BUILD_DIR/.apt/usr/bin/Xvfb
 	# create symlinks for Xvfb to use /app/.apt/usr/...
 	ln -s /app/.apt/usr/bin /app/nib
 }


### PR DESCRIPTION
I think this fixes #1 - when adding this buildpack to a new Heroku app, Xvfb does not exist in `/app` yet during `freedom_patch_xvfb` (I think the `.apt` dir gets moved to `/app` from `$BUILD_DIR` later?)

The buildpack `compile` completes with this change, but I think some of the QT config isn't set correctly, because for an app using `heroku/ruby` as a second buildpack, attempting to `gem install capybara-webkit` fails with `Could not find qmake configuration file linux-g++-64` even though `linux-g++-64` exists in `mkspecs`.

`qmake --version` shows `QFileSystemEngine::currentPath: getcwd() failed`.

/cc @damaneice @hone 